### PR TITLE
Add an option to create a new notebook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,11 @@ def main(argv=None):
                   "License :: OSI Approved :: BSD License",
                   "Programming Language :: Python :: 2",
                   "Programming Language :: Python :: 3",
-                 ],
-             **extra_options)
+              ],
+              install_requires=[
+                  "nbformat"
+              ],
+              **extra_options)
 
     finally:
         if argv is not None:


### PR DESCRIPTION
This code adds a simple command line option to create a new notebook if one doesn't already exist. It does some obvious checks to see if the file exists (either with or without the `.ipynb` extension) but I may have missed something.

I saw that you said elsewhere that you see this as mainly for GUI integration, but I've been using nbopen at the console regularly since installing it a couple of weeks ago, and I have already wanted to open a new notebook from the console multiple times, so I thought others might find this useful too. 

Open to feedback and happy to change anything you like!
