### PR TITLE
Convert path to use slashes on Windows v2

### DIFF
--- a/nbopen/nbopen.py
+++ b/nbopen/nbopen.py
@@ -26,7 +26,7 @@ def nbopen(filename):
         print("Using existing server at", server_inf['notebook_dir'])
         path = os.path.relpath(filename, start=server_inf['notebook_dir'])
         if os.sep != '/':
-            path.replace(os.sep, '/')
+            path = path.replace(os.sep, '/')
         url = url_path_join(server_inf['url'], 'notebooks', url_escape(path))
         na = notebookapp.NotebookApp.instance()
         na.load_config_file()


### PR DESCRIPTION
 added  assignment missing in 31a17f9  (string.replace is not inplace)