### PR TITLE
backport to 2.7

### DIFF
--- a/nbopen/install_xdg.py
+++ b/nbopen/install_xdg.py
@@ -2,7 +2,7 @@
 import os
 from pathlib import Path
 import shutil
-from subprocess import run
+from subprocess import call, CalledProcessError
 
 _PKGDIR = Path(__file__).resolve().parent
 
@@ -13,20 +13,21 @@ print("Installing data files to:", os.environ['XDG_DATA_HOME'])
 #export XDG_UTILS_DEBUG_LEVEL=1  #DEBUG
 
 print('Installing mimetype data...')
-run(['xdg-mime', 'install', str(_PKGDIR / 'application-x-ipynb+json.xml')],
-    check=True)
+if call(['xdg-mime', 'install', str(_PKGDIR / 'application-x-ipynb+json.xml')]) != 0:
+    raise CalledProcessError
 
 print('Installing icons...')
 for s in [16, 24, 32, 48, 64, 128, 256, 512]:
     src = _PKGDIR / "icons/ipynb_icon_{s}x{s}.png".format(s=s)
-    run(['xdg-icon-resource', 'install', '--noupdate', '--size', str(s),
-         '--context', 'mimetypes', str(src), 'application-x-ipynb+json'],
-        check=True)
+    if call(['xdg-icon-resource', 'install', '--noupdate', '--size', str(s),
+         '--context', 'mimetypes', str(src), 'application-x-ipynb+json']) != 0:
+         raise CalledProcessError
 
-run(['xdg-icon-resource', 'forceupdate'], check=True)
+if call(['xdg-icon-resource', 'forceupdate']) != 0:
+    raise CalledProcessError
 
 print('Installing desktop file...')
 apps_dir = os.path.join(os.environ['XDG_DATA_HOME'], "applications/")
 shutil.copy2(str(_PKGDIR / 'nbopen.desktop'), apps_dir)
-run(['update-desktop-database', apps_dir], check=True)
-
+if call(['update-desktop-database', apps_dir]) != 0:
+    raise CalledProcessError


### PR DESCRIPTION
Tried backporting to 2.7 so the file association could be used with default linux python, seems to work. 