### PR TITLE
Add Icon=jupyter to nbopen.desktop

### DIFF
--- a/nbopen/nbopen.desktop
+++ b/nbopen/nbopen.desktop
@@ -7,3 +7,4 @@ NoDisplay=true
 Exec={PYTHON} -m nbopen %f
 Terminal=false
 MimeType=application/x-ipynb+json;
+Icon=jupyter


### PR DESCRIPTION
Instead of a generic "executable" icon, this makes some file browsers (e.g. nautilus) show a Jupyter icon in the "open with ..." list. The icon is automatically selected from the system's icon pack. 
![image](https://user-images.githubusercontent.com/26322692/186848255-f0cafe6e-5068-4701-8808-5e680d3172a2.png)